### PR TITLE
Fix: 24시간 상주 선택시 스케줄 선택란 처리

### DIFF
--- a/src/components/SelectBox.jsx
+++ b/src/components/SelectBox.jsx
@@ -1,9 +1,9 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { ReactComponent as DropdownIcon } from '../assets/chevron_down_icon.svg';
 import { ReactComponent as CloseIcon } from '../assets/close_icon.svg';
 
-export default function SelectBox({ name, data, selected, setSelected }) {
+export default function SelectBox({ name, data, selected, setSelected, disabled }) {
   const [openMenu, setOpenMenu] = useState(false);
 
   const onOpenMenu = () => {
@@ -14,14 +14,25 @@ export default function SelectBox({ name, data, selected, setSelected }) {
     setOpenMenu(false);
   };
 
+  useEffect(() => {
+    if (disabled) {
+      setSelected('24시간');
+    } else {
+      setSelected();
+    }
+  }, [disabled]);
   return (
     <>
       <Dropdown>
         <label>{name}</label>
-        <Dropdown.Button onClick={onOpenMenu}>
-          <span>{selected ? selected : '선택'}</span>
-          <DropdownIcon />
-        </Dropdown.Button>
+        {disabled ? (
+          <Dropdown.Button>{selected}</Dropdown.Button>
+        ) : (
+          <Dropdown.Button onClick={onOpenMenu}>
+            <span>{selected ? selected : '선택'}</span>
+            <DropdownIcon />
+          </Dropdown.Button>
+        )}
       </Dropdown>
       <Overlay show={openMenu} onClick={onCloseMenu}>
         <MenuWrapper show={openMenu} onClick={(e) => e.stopPropagation()}>

--- a/src/pages/StepApplymentBrief.jsx
+++ b/src/pages/StepApplymentBrief.jsx
@@ -125,7 +125,7 @@ export default function StepApplymentBrief() {
               <Body4>
                 {schedule.startDate} ~ {schedule.endDate}
               </Body4>
-              <Body4>{schedule.visitTime}부터</Body4>
+              <Body4>{schedule.visitTime !== '24시간' && schedule.visitTime + '부터'}</Body4>
               <Body4>{schedule.hour}</Body4>
             </DetailContainer>
             <Separator />

--- a/src/pages/StepSchedule.jsx
+++ b/src/pages/StepSchedule.jsx
@@ -15,6 +15,7 @@ export default function StepSchedule() {
     () => applymentBrief?.schedule || {},
     [applymentBrief?.schedule]
   );
+  const workType = useMemo(() => applymentBrief?.workType, [applymentBrief?.workType]);
   const [modalOpen, setModalOpen] = useState(false);
   const [duration, setDuration] = useState(startDate ? [startDate, endDate] : []);
   const [careStartTime, setCareStartTime] = useState(visitTime || null);
@@ -60,12 +61,14 @@ export default function StepSchedule() {
           data={timeList}
           selected={careStartTime}
           setSelected={setCareStartTime}
+          disabled={workType === 'DAY'}
         />
         <SelectBox
           name="하루 돌봄 시간"
           data={careTimeList}
           selected={careTime}
           setSelected={setCareTime}
+          disabled={workType === 'DAY'}
         />
       </Container>
       {modalOpen && <ScheduleModal onClose={onCloseModal} />}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항

24시간 상주 선택시 시간 스케줄 선택란 선택 불가 처리 및 24시간으로 결과에 나타나도록 수정했습니다.
이전 화면에서 시간제로 변경 후 돌아왔을 때를 고려한 처리도 함께 해두었습니다.

### 테스트 결과
<img width="369" alt="스크린샷 2022-03-11 오후 3 00 00" src="https://user-images.githubusercontent.com/50618754/157811238-de1a2c8a-f3d5-4caa-b3c1-665356d3d94e.png">


resolved: #
